### PR TITLE
Websiteのデザインテーマを追加 #8

### DIFF
--- a/src/app/Store/ThemeContext.tsx
+++ b/src/app/Store/ThemeContext.tsx
@@ -99,10 +99,8 @@ export const switchingTheme = (params: TThemeParams) => {
     switch (params.selected_theme) {
       case "white":
         return themeWhite(params)
-        break;
       case "natural":
         return themeNatural(params)
-        break;
 
       default:
         return themeWhite(params)

--- a/src/app/Store/Types.ts
+++ b/src/app/Store/Types.ts
@@ -7,7 +7,7 @@ export type T_shop_name = string;
 export type T_user_email = string;
 export type T_show_article_type = 'scroll' | 'grid6'
 
-export type T_selected_theme = 'white' | 'natural';
+export type T_selected_theme = 'default' | 'white' | 'natural';
 export type T_theme_color = string;
 export type T_theme_font = TFont1[0] | TFont2[0];
 export type T_footer_icon_size = "medium" | "small";

--- a/src/app/Store/themes/paramsFromTheme.ts
+++ b/src/app/Store/themes/paramsFromTheme.ts
@@ -2,6 +2,14 @@ import { T_selected_theme } from "../Types";
 import { TThemeParams } from "../ThemeContext";
 import { selectedIconReducer } from "../../Reducer/selectedIconReducer";
 
+const defaultTheme: TThemeParams = {
+  selected_theme: 'default',
+  theme_color: "#311b92",
+  theme_font1: "未設定",
+  theme_font2: '"M PLUS Rounded 1c"',
+  theme_font_heading: '"M PLUS Rounded 1c"',
+};  
+
 const white: TThemeParams = {
   selected_theme: 'white',
   theme_color: "#263238",
@@ -22,6 +30,8 @@ export const generateDefaultParamsFromTheme = (
          selectedTheme: T_selected_theme
        ): TThemeParams => {
          switch (selectedTheme) {
+           case "default":
+             return defaultTheme;
            case "white":
              return white;
            case "natural":

--- a/src/app/Store/themes/paramsFromTheme.ts
+++ b/src/app/Store/themes/paramsFromTheme.ts
@@ -1,6 +1,9 @@
 import { T_selected_theme } from "../Types";
 import { TThemeParams } from "../ThemeContext";
 import { selectedIconReducer } from "../../Reducer/selectedIconReducer";
+import { themeWhite } from "./themeWhite";
+import { themeNatural } from "./themeNatural";
+import { themeDefault } from "./themeDefault";
 
 const defaultTheme: TThemeParams = {
   selected_theme: 'default',
@@ -38,7 +41,7 @@ export const generateDefaultParamsFromTheme = (
              return natural;
 
            default:
-             break;
+             return defaultTheme;
          }
        };
 

--- a/src/app/Store/themes/themeDefault.ts
+++ b/src/app/Store/themes/themeDefault.ts
@@ -1,0 +1,102 @@
+import { createMuiTheme } from "@material-ui/core";
+import { TThemeParams } from "../ThemeContext";
+import { Deprecated_FontNameToFontFamily } from "./fonts";
+import { secondaryColor } from "../../../lib/color/secondaryColor";
+
+const theme = createMuiTheme();
+
+export const themeDefault= (params: TThemeParams) =>
+  createMuiTheme({
+    overrides: {
+      MuiCssBaseline: {
+        "@global": {
+          a: {
+            color: "#607d8b",
+          },
+          h1: {
+            fontWeight: "500",
+          },
+          h2: {
+            fontWeight: "500",
+          },
+        },
+      },
+      MuiPaper: {
+        rounded: {
+          borderRadius: theme.spacing(3),
+        },
+      },
+      MuiDrawer: {
+        paper: {
+          MozBorderRadiusTopright: theme.spacing(3),
+          MozBorderRadiusBottomright: theme.spacing(3),
+        },
+      },
+    },
+
+    typography: {
+      fontFamily: [
+        // "未設定",
+        params.theme_font1,
+
+        params.theme_font2,
+        '"游ゴシック体"',
+        "sans-serif",
+      ].join(","),
+      fontWeightLight: 200,
+      fontWeightRegular: 300,
+      fontWeightMedium: 400,
+      fontWeightBold: 500,
+      h1: {
+        fontFamily: `${params.theme_font1}, ${params.theme_font_heading}`,
+      },
+      h2: {
+        fontFamily: `${params.theme_font1}, ${params.theme_font_heading}`,
+      },
+      h3: {
+        fontFamily: `${params.theme_font1}, ${params.theme_font_heading}`,
+      },
+      h4: {
+        fontFamily: `${params.theme_font1}, ${params.theme_font_heading}`,
+        fontWeight: 400,
+      },
+      h5: {
+        fontFamily: `${params.theme_font1}, ${params.theme_font_heading}`,
+        fontWeight: 400,
+      },
+      h6: {
+        fontFamily: `${params.theme_font1}, ${params.theme_font_heading}`,
+        fontWeight: 500,
+      },
+    },
+    palette: {
+      primary: {
+        main: params.theme_color,
+      },
+      secondary: {
+        main: secondaryColor(params.theme_color),
+      },
+      text: {
+        primary: "rgba(0, 0, 0, 0.95)",
+        secondary: "rgba(0, 0, 0, 0.77)",
+        disabled: "rgba(0, 0, 0, 0.54)",
+        hint: "rgba(0, 0, 0, 0.54)",
+      },
+    },
+
+    props: {
+      MuiPaper: {
+        variant: "elevation",
+        elevation: 2,
+      },
+      MuiTextField: {
+        variant: "standard",
+      },
+      MuiButton: {
+        variant: "outlined",
+      },
+      MuiFormControl: {
+        variant: "standard",
+      },
+    },
+  });

--- a/src/app/View/Drawer/ManageTheme/ManageTheme.tsx
+++ b/src/app/View/Drawer/ManageTheme/ManageTheme.tsx
@@ -24,6 +24,7 @@ import AccordionDetails from '@material-ui/core/AccordionDetails';
 import AccordionSummary from '@material-ui/core/AccordionSummary';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import {isThemeParamsChanged} from '../../../Store/themes/paramsFromTheme'
+import { useAuth } from "../../../../lib/auth/AuthProvider";
 var colorConvert = require("color-convert");
 
 export type THsl = {
@@ -43,6 +44,7 @@ export const useManageTheme = () => {
   const [footerIconSize, setFooterIconSize] = React.useState(
     footer_icon_size
   );
+  const { user } = useAuth()
   const changeTheme = useChangeTheme()
   const changeThemeColor = useChangeThemeColor()
   const changeThemeFont = useChangeThemeFont()
@@ -130,6 +132,7 @@ export const useManageTheme = () => {
     show_article_type,
     handleChange,
     handleChangeShowArticleType,
+    user,
   };
 
 }

--- a/src/app/View/Drawer/ManageTheme/SelectTheme.tsx
+++ b/src/app/View/Drawer/ManageTheme/SelectTheme.tsx
@@ -13,6 +13,12 @@ export const SelectTheme = (props: TUseManageThemeProps) => {
                value={props.selected_theme}
                onChange={props.handleChange}
              >
+               {props.user? <FormControlLabel
+                 value="default"
+                 control={<Radio />}
+                 label="デフォルト"
+               /> : null}
+
                <FormControlLabel
                  value="white"
                  control={<Radio />}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -17,6 +17,9 @@ import WebSiteDrawer from "../pageComponent/WebsiteDrawer";
 import { googleFontsUrl } from "../lib/googleFontsUrl";
 import { AuthProvider } from "../lib/auth/AuthProvider";
 import { AppProps } from "next/dist/next-server/lib/router/router";
+import { MuiThemeProvider } from "@material-ui/core";
+import { themeDefault } from "../app/Store/themes/themeDefault";
+import { generateDefaultParamsFromTheme } from "../app/Store/themes/paramsFromTheme";
 
 export default function MyApp({ Component, pageProps, slug }: AppProps) {
   const session = pageProps.session
@@ -37,9 +40,12 @@ export default function MyApp({ Component, pageProps, slug }: AppProps) {
           {session ? 
             <Component {...pageProps} />
             : 
-            <WebSiteDrawer id="back-to-top-anchor">
-              <Component {...pageProps} />
-            </WebSiteDrawer>
+            <MuiThemeProvider theme={themeDefault(generateDefaultParamsFromTheme('default'))}>
+              <WebSiteDrawer id="back-to-top-anchor">
+                <Component {...pageProps} />
+              </WebSiteDrawer>
+
+            </MuiThemeProvider>
           }
         </AuthProvider>
       </>

--- a/src/stories/_DesignBoard.stories.tsx
+++ b/src/stories/_DesignBoard.stories.tsx
@@ -1,6 +1,6 @@
 import { Button, createStyles, makeStyles, Typography, Theme, TextField, Paper, useTheme, Box, Chip } from '@material-ui/core';
 import React from 'react';
-import { Provider, StorybookStore } from './lib/ThemeProvider';
+import { ThemeProvider, StorybookStore } from "./lib/ThemeProvider";
 import Dialog from '@material-ui/core/Dialog';
 import DialogActions from '@material-ui/core/DialogActions';
 import DialogContent from '@material-ui/core/DialogContent';
@@ -160,7 +160,7 @@ const DesignBoard:React.FC = () => {
 export default {
   title: '_DesignBoard',
   component: DesignBoard,
-  decorators: [story => <Provider >{story()}</Provider>],
+  decorators: [story => <ThemeProvider >{story()}</ThemeProvider>],
 };
 
 export const Normal = () => {

--- a/src/stories/lib/ThemeProvider.tsx
+++ b/src/stories/lib/ThemeProvider.tsx
@@ -37,7 +37,7 @@ type TStorybookStore = {
 export const StorybookStore = React.createContext({} as TStorybookStore);
 
 
-export const Provider: React.FC = (props) => {
+export const ThemeProvider: React.FC = (props) => {
 
   const [selected_theme, setSelected_theme] = React.useState('white' as T_selected_theme)
 
@@ -59,7 +59,7 @@ export const Provider: React.FC = (props) => {
       <CssBaseline />
       <StorybookStore.Provider value={values}>
         <ThemeContext.Provider value={useThemeArgs('medium')}>
-          <SelectTheme {...selectThemeProps}  selected_theme={selected_theme} handleChange={handleChange}/>
+          <SelectTheme {...selectThemeProps}  selected_theme={selected_theme} handleChange={handleChange} user={true}/>
           <div style={border} ></div>
           {props.children}
         </ThemeContext.Provider>


### PR DESCRIPTION
why

websiteのmaterial ui のpropsも管理しやすくするため

what

defaultThemeを追加して, MuiProviderをつかってwebsiteに反映