### PR TITLE
サインイン/サインアップエラーで AuthCircularキャンセル #7

### DIFF
--- a/src/app/View/tablet/Drawer/Drawer/context/useHandleOnSingOut.ts
+++ b/src/app/View/tablet/Drawer/Drawer/context/useHandleOnSingOut.ts
@@ -9,6 +9,7 @@ export const useHandleOnSingOut = () => {
     if(signOuting) {
       setIsClicked(true)
       signout("/");
+      setIsClicked(false);
     }
   }
 

--- a/src/pageComponent/AuthFrom.tsx
+++ b/src/pageComponent/AuthFrom.tsx
@@ -12,7 +12,6 @@ import firebase from "firebase/app";
 import "firebase/auth";
 import { useRouter } from "next/router";
 import nookies from "nookies";
-import { AuthCircular } from "../lib/AuthCircular";
 
 initFirebase();
 
@@ -66,9 +65,20 @@ export const AuthForm:React.FC<TAuthForm> = (props) => {
     router.push('/')
 
     } catch (error) {
-      var errorCode = error.code;
-      var errorMessage = error.message;
-      console.log("signInWithEmailAndPasswordでエラー " + error.message);
+      const errorMessage = error.message;
+      const errorCode = error.code;
+      if (errorCode === "auth/wrong-password") {
+        alert('メールアドレス、もしくはパスワードが間違っています。');
+      }
+      if (errorCode === "auth/invalid-email") {
+        alert("正しいメールアドレスではありません。");
+      }
+      if (errorCode === "auth/weak-password") {
+        alert("パスワード強度が低すぎます。より複雑な英数字の組み合わせ6文字以上にしてください。");
+      }
+      props.setIsClicked(false);
+      
+      console.log(errorMessage);
     }
 
   };


### PR DESCRIPTION
why

サインインに失敗すると操作できなくなるバグ修正

what

パスワード強度や、メールアドレス不正のエラーにも対応してエラーメッセージ出すようにした