### PR TITLE
Is generate public page修正 #27

### DIFF
--- a/src/lib/checkIsGeneratePubulicPage.ts
+++ b/src/lib/checkIsGeneratePubulicPage.ts
@@ -1,23 +1,22 @@
-import { db } from "./db";
 import { TUserInfo } from "../app/Store/Interface";
+import { db } from "./db";
 import { userInfoParamsFromSql } from "./userInfoParamsFromSql";
 
 // サーバーサイドとフロントサイド考えずに使えるようにラップする
-export const getUserInfoFromSlug = async (
+export const checkIsGeneratePubulicPage = async (
          slug: string
        ): Promise<TUserInfo> => {
          //@ts-ignore
          const data: TUserInfo[] = await db(`SELECT * FROM user_info`);
 
          const target = data.filter((value) => {
-           return value.public_page_slug === slug;
+           return (value.public_page_slug === slug && value.is_generate_public_page);
          });
 
          if (target.length) {
-          return userInfoParamsFromSql(target[0]);
+           return userInfoParamsFromSql(target[0]);
          } else {
-          return null
+           return null;
          }
-
        };
 

--- a/src/pages/api/user_info/switch_generate_public_page.ts
+++ b/src/pages/api/user_info/switch_generate_public_page.ts
@@ -23,8 +23,6 @@ export type T_user_info_switch_generate_public_page_return = {
 
 const switch_generate_public_page = async (req: NextApiRequest, res: NextApiResponse) => {
   if (req.method === "POST") {
-
-    console.log('switch_generate_public_pageのreq.bodyは ' + JSON.stringify(req.body));
     
     const {
       is_generate_public_page,
@@ -37,8 +35,6 @@ const switch_generate_public_page = async (req: NextApiRequest, res: NextApiResp
         `UPDATE user_info SET is_generate_public_page = ? WHERE user_id = ?`,
         [is_generate_public_page, user_id]
       );
-
-        console.log("/user_info/switch_generate_public_page/は " + JSON.stringify(data));
 
         const returnData: T_user_info_switch_generate_public_page_return = {
           is_generate_public_page: is_generate_public_page

--- a/src/pages/public_page/[public_page_slug].tsx
+++ b/src/pages/public_page/[public_page_slug].tsx
@@ -6,18 +6,37 @@ import Head from 'next/head';
 import parser from "ua-parser-js";
 import { IndexProps } from '..';
 import { checkIsGeneratePubulicPage } from '../../lib/checkIsGeneratePubulicPage';
+import { makeStyles, Typography, Theme, createStyles } from "@material-ui/core";
 
-
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    typography: {
+      margin: theme.spacing(3),
+    },
+  })
+);
 
 const PublicPage = (props: IndexProps) => {
+  const classes = useStyles()
 
   if (props.isPublicPage === false) {
-    return (<>
-      <Head>
-        <meta name="robots" content="noindex" />
-      </Head>
-      <p>パブリックページが有効化されていません</p>
-    </>)
+    return (
+      <>
+        <Head>
+          <meta name="robots" content="noindex" />
+        </Head>
+        <Typography
+          className={classes.typography}
+          align="center"
+          variant="h4"
+          component="h2"
+          gutterBottom
+          color="textSecondary"
+        >
+          パブリックページが有効化されていません
+        </Typography>
+      </>
+    );
   }
 
   return (

--- a/src/pages/public_page/[public_page_slug].tsx
+++ b/src/pages/public_page/[public_page_slug].tsx
@@ -1,15 +1,24 @@
 import React from 'react'
 import { GetServerSideProps } from "next";
-import { getUserInfoFromSlug } from "../../lib/getUserInfoFromSlug";
 import { generateProps } from '../../lib/generateProps';
 import App from '../../app/View/App';
 import Head from 'next/head';
 import parser from "ua-parser-js";
 import { IndexProps } from '..';
+import { checkIsGeneratePubulicPage } from '../../lib/checkIsGeneratePubulicPage';
 
 
 
 const PublicPage = (props: IndexProps) => {
+
+  if (props.isPublicPage === false) {
+    return (<>
+      <Head>
+        <meta name="robots" content="noindex" />
+      </Head>
+      <p>パブリックページが有効化されていません</p>
+    </>)
+  }
 
   return (
     <>
@@ -32,16 +41,16 @@ export const getServerSideProps: GetServerSideProps = async ({req, res, query}) 
   const device = ua.getDevice().type;
   
   // slugがDBにあるかどうかチェックして、「表示させているか？」「slug」を返す
-  const userInfo = await getUserInfoFromSlug(SlugArray[0]);
+  const userInfo = await checkIsGeneratePubulicPage(SlugArray[0]);
 
   if (userInfo === null) {
-    res.statusCode = 302;
-    res.setHeader(
-      "Location",
-      `/public_page/wrong_url?wrong_slug=${slicedSlug}`
-    ); 
-    res.end()
-    return { props: null };
+    // res.statusCode = 302;
+    // res.setHeader(
+    //   "Location",
+    //   `/public_page/wrong_url?wrong_slug=${slicedSlug}`
+    // ); 
+    // res.end()
+    return { props: {isPublicPage: false} };
   }
 
   const returnData: IndexProps = {


### PR DESCRIPTION
why

パブリックページが設定に関わらず表示できてしまっていた。

what

切り替えロジックを実装し、表示がオフの時にアクセスすると簡易なメッセージを表示させるようにした。